### PR TITLE
Fixes #3 UnicodeEncodeError: 'ascii' codec can't encode characters

### DIFF
--- a/centos_package_cron/command_line.py
+++ b/centos_package_cron/command_line.py
@@ -4,6 +4,8 @@
 import argparse
 import socket
 import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 from report_producer import ReportProducer
 from db_session_fetcher import db_session_fetcher
 import smtplib


### PR DESCRIPTION
These changes should allow output redirection of the script.